### PR TITLE
dispatch ConsoleExceptionEvent on daemon exception

### DIFF
--- a/src/M6Web/Bundle/DaemonBundle/Command/DaemonCommand.php
+++ b/src/M6Web/Bundle/DaemonBundle/Command/DaemonCommand.php
@@ -3,6 +3,8 @@
 namespace M6Web\Bundle\DaemonBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -171,6 +173,9 @@ abstract class DaemonCommand extends ContainerAwareCommand
             } catch (\Exception $e) {
                 $this->setLastException($e);
                 $this->dispatchEvent(DaemonEvents::DAEMON_LOOP_EXCEPTION_GENERAL);
+
+                $event = new ConsoleExceptionEvent($this, $input, $output, $e, $e->getCode());
+                $this->dispatcher->dispatch(ConsoleEvents::EXCEPTION, $event);
 
                 if ($this->getShowExceptions()) {
                     $this->getApplication()->renderException($e, $output);

--- a/src/M6Web/Bundle/DaemonBundle/Tests/Units/Command/DaemonCommand.php
+++ b/src/M6Web/Bundle/DaemonBundle/Tests/Units/Command/DaemonCommand.php
@@ -238,10 +238,10 @@ class DaemonCommand extends test
     public function testCommandException()
     {
         $eventDispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcher();
-        $lastEvent       = null;
+        $lastEvents      = [];
 
-        $eventDispatcher->getMockController()->dispatch = function($name, $eventObject) use(&$lastEvent) {
-            $lastEvent = $eventObject;
+        $eventDispatcher->getMockController()->dispatch = function ($name, $eventObject) use (&$lastEvents) {
+            $lastEvents[$name] = $eventObject;
             return true;
         };
 
@@ -268,13 +268,17 @@ class DaemonCommand extends test
                 ->output($commandTester->getDisplay())
                     ->notContains(DaemonCommandConcreteThrowException::$exceptionMessage)
                     ->notContains('Exception')
-                ->object($lastEvent)
+                ->object($lastEvents['console.exception'])
+                    ->isInstanceOf('Symfony\Component\Console\Event\ConsoleExceptionEvent')
+                ->object($lastEvents['console.exception']->getException())
+                    ->isEqualTo($command->getLastException())
+                ->object(end($lastEvents))
                     ->isInstanceOf('M6Web\Bundle\DaemonBundle\Event\DaemonEvent')
-                ->object($lastEvent->getCommand())
+                ->object(end($lastEvents)->getCommand())
                     ->isInstanceOf('M6Web\Bundle\DaemonBundle\Tests\Units\Command\DaemonCommandConcreteThrowException')
-                ->object($lastEvent->getCommand()->getLastException())
+                ->object(end($lastEvents)->getCommand()->getLastException())
                     ->isInstanceOf('Exception')
-                ->string($lastEvent->getCommandLastExceptionClassName())
+                ->string(end($lastEvents)->getCommandLastExceptionClassName())
                     ->isEqualTo('Exception')
         ;
     }


### PR DESCRIPTION
Dispatch a **ConsoleExceptionEvent** event on exception.

Symfony console application dispatch this event ([see](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Application.php#L833-L834)). The daemon command should dispatch it too.

This is useful for logging purpose (http://symfony.com/doc/current/cookbook/console/logging.html#enabling-automatic-exceptions-logging).