### PR TITLE
fix configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/framework-bundle" : "~3.0"
     },
     "require-dev" : {
-        "atoum/atoum" : "master-dev"
+        "atoum/atoum" : "master-dev",
+        "symfony/yaml": "~3.0"
     },
     "autoload" : {
         "psr-0" : {

--- a/src/M6Web/Bundle/DaemonBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/DaemonBundle/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('iterations_events')
                 ->prototype('array')
                     ->children()
-                        ->integerNode('count')->cannotBeEmpty()->min(1)->end()
+                        ->integerNode('count')->min(1)->end()
                         ->scalarNode('name')->cannotBeEmpty()->end()
                     ->end()
                 ->end()

--- a/src/M6Web/Bundle/DaemonBundle/Tests/Fixtures/bad-parameters-config.yml
+++ b/src/M6Web/Bundle/DaemonBundle/Tests/Fixtures/bad-parameters-config.yml
@@ -1,0 +1,5 @@
+m6_web_daemon:
+    iterations_events:
+      -
+        count: ~
+        name: test

--- a/src/M6Web/Bundle/DaemonBundle/Tests/Fixtures/default-config.yml
+++ b/src/M6Web/Bundle/DaemonBundle/Tests/Fixtures/default-config.yml
@@ -1,0 +1,5 @@
+m6_web_daemon:
+    iterations_events:
+      -
+        count: 1
+        name: test

--- a/src/M6Web/Bundle/DaemonBundle/Tests/Units/DependencyInjection/M6WebDaemonExtension.php
+++ b/src/M6Web/Bundle/DaemonBundle/Tests/Units/DependencyInjection/M6WebDaemonExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace M6Web\Bundle\DaemonBundle\Tests\Units\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+use mageekguy\atoum\test;
+
+
+class M6WebDaemonExtension extends test
+{
+    public function testDefaultConfig()
+    {
+        $container = $this->getContainerForConfiguration('default-config');
+        $container->compile();
+        $this
+            ->array($iterationEvents = $container->getParameter('m6web_daemon.iterations_events'))
+                ->hasSize(1)
+            ->array($iterationEvent = current($iterationEvents))
+                ->hasKeys(['count', 'name'])
+            ->integer($iterationEvent['count'])
+                ->isEqualTo(1)
+            ->string($iterationEvent['name'])
+                ->isEqualTo('test')
+        ;
+    }
+
+    public function testMissingCountConfig()
+    {
+        $container = $this->getContainerForConfiguration('bad-parameters-config');
+        $this
+            ->exception(function() use ($container) {
+                $container->compile();
+            })->isInstanceOf('Symfony\Component\Config\Definition\Exception\InvalidTypeException')
+        ;
+    }
+
+    protected function getContainerForConfiguration($fixtureName)
+    {
+        $className = $this->getTestedClassName();
+        $extension = new $className();
+
+        $container = new ContainerBuilder();
+        $container->set('event_dispatcher', new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface());
+        $container->registerExtension($extension);
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../../Fixtures/'));
+        $loader->load($fixtureName.'.yml');
+
+        return $container;
+    }
+}


### PR DESCRIPTION
With sf3, i got this error : 

```
 [Symfony\Component\Config\Definition\Exception\InvalidDefinitionException]    
    ->cannotBeEmpty() is not applicable to NumericNodeDefinition.
```