### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: php
 php:
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/framework-bundle" : "~3.0"
     },
     "require-dev" : {
-        "atoum/atoum" : "master-dev",
+        "atoum/atoum" : "^2.8||^3.0",
         "symfony/yaml": "~3.0"
     },
     "autoload" : {


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.