### PR TITLE
Remove php5.5 build on travis since it's not supported anymore by PHP itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
 
 before_script:
   - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - php composer.phar install
 
 script:
   - vendor/bin/atoum


### PR DESCRIPTION
the main issue here is that our builds are failing only on PHP5.5 for an obscure reason 

```shell
$ wget http://getcomposer.org/composer.phar
--2018-02-16 20:05:40--  http://getcomposer.org/composer.phar
Resolving getcomposer.org (getcomposer.org)... 142.44.245.229, 2607:5300:201:2100::4:d105
Connecting to getcomposer.org (getcomposer.org)|142.44.245.229|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1863764 (1.8M) [application/octet-stream]
Saving to: ‘composer.phar’
100%[======================================>] 1,863,764   6.64MB/s   in 0.3s   
2018-02-16 20:05:40 (6.64 MB/s) - ‘composer.phar’ saved [1863764/1863764]
2.42s$ php composer.phar install --dev
You are using the deprecated option "dev". Dev packages are installed by default now.
Loading composer repositories with package information
Updating dependencies (including require-dev)
                                                                               
  [Composer\Downloader\TransportException]                                     
  The "http://packagist.org/p/provider-2017%24f4f8ba40be4dd14334064adefdea3e8  
  28b52be06d236690c0f606c58d6cc55fb.json" file could not be downloaded (HTTP/  
  1.1 404 Not Found)                                                           
                                                                               
install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...
The command "php composer.phar install --dev" failed and exited with 255 during .
Your build has been stopped.
```

see PHP supported versions http://php.net/supported-versions.php