### PR TITLE
Make service public for sf4 compatibility

### DIFF
--- a/src/M6Web/Bundle/DaemonBundle/Resources/config/services.yml
+++ b/src/M6Web/Bundle/DaemonBundle/Resources/config/services.yml
@@ -2,3 +2,4 @@ services:
     m6_daemon_bundle.event_loop:
         class: 'React\EventLoop\LoopInterface'
         factory: ['React\EventLoop\Factory', 'create']
+        public: true


### PR DESCRIPTION
The event_loop is accessed at runtime here https://github.com/M6Web/DaemonBundle/blob/ed5e308381dca9d13d5ea17ab43de7b7b7c91e82/src/M6Web/Bundle/DaemonBundle/Command/DaemonCommand.php#L209