### PR TITLE
Chore/compatibilty symfo7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ['8.2']
-        symfony-version: ['^7.0']
+        php-version: ['8.1', '8.2']
+        symfony-version: ['^6.1', '^7.0']
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         php-version: ['8.1', '8.2']
         symfony-version: ['^6.1', '^7.0']
+        exclude:
+          - php-version: '8.1'
+            symfony-version: '^7.0'
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ['8.1']
-        symfony-version: ['^6.1']
+        php-version: ['8.2']
+        symfony-version: ['^7.0']
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require" : {
-        "php" : ">=8.1",
+        "php" : ">=8.2",
         "ext-pcntl" : "*",
         "psr/event-dispatcher": ">=1.0",
-        "symfony/console" : "~6.1",
-        "symfony/framework-bundle" : "~6.1",
-        "symfony/yaml": "~6.1",
+        "symfony/console" : "~7.0",
+        "symfony/framework-bundle" : "~7.0",
+        "symfony/yaml": "~7.0",
         "react/event-loop": "@stable"
     },
     "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require" : {
-        "php" : ">=8.2",
+        "php" : ">=8.1",
         "ext-pcntl" : "*",
         "psr/event-dispatcher": ">=1.0",
-        "symfony/console" : "~7.0",
-        "symfony/framework-bundle" : "~7.0",
-        "symfony/yaml": "~7.0",
+        "symfony/console" : "~6.1||~7.0",
+        "symfony/framework-bundle" : "~6.1||~7.0",
+        "symfony/yaml": "~6.1||~7.0",
         "react/event-loop": "@stable"
     },
     "require-dev" : {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('m6_web_daemon');
 

--- a/src/DependencyInjection/M6WebDaemonExtension.php
+++ b/src/DependencyInjection/M6WebDaemonExtension.php
@@ -11,8 +11,9 @@ class M6WebDaemonExtension extends Extension
 {
     /**
      * {@inheritdoc}
+     * @throws \Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Event/AbstractDaemonEvent.php
+++ b/src/Event/AbstractDaemonEvent.php
@@ -8,10 +8,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 abstract class AbstractDaemonEvent extends Event
 {
     /** @var DaemonCommand */
-    protected $command;
+    protected DaemonCommand $command;
 
     /** @var float */
-    protected $executionTime;
+    protected float $executionTime;
 
     public function __construct(DaemonCommand $command)
     {

--- a/tests/Fixtures/Command/DaemonCommandConcrete.php
+++ b/tests/Fixtures/Command/DaemonCommandConcrete.php
@@ -3,6 +3,7 @@
 namespace M6Web\Bundle\DaemonBundle\Tests\Fixtures\Command;
 
 use M6Web\Bundle\DaemonBundle\Command\DaemonCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -15,7 +16,8 @@ class DaemonCommandConcrete extends DaemonCommand
              ->setDescription('command for unit test');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        return Command::SUCCESS;
     }
 }

--- a/tests/Fixtures/Command/DaemonCommandConcreteIterationCallback.php
+++ b/tests/Fixtures/Command/DaemonCommandConcreteIterationCallback.php
@@ -3,15 +3,16 @@
 namespace M6Web\Bundle\DaemonBundle\Tests\Fixtures\Command;
 
 use M6Web\Bundle\DaemonBundle\Command\DaemonCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DaemonCommandConcreteIterationCallback extends DaemonCommand
 {
-    public $countCall = 0;
-    public $iterationInterval = 5;
+    public int $countCall = 0;
+    public int $iterationInterval = 5;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('test:daemontest')
@@ -23,8 +24,9 @@ class DaemonCommandConcreteIterationCallback extends DaemonCommand
         $this->addIterationsIntervalCallback($this->iterationInterval, [$this, 'myCallback']);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        return Command::SUCCESS;
     }
 
     protected function myCallback(InputInterface $input, OutputInterface $output): void

--- a/tests/Fixtures/Command/DaemonCommandConcreteThrowException.php
+++ b/tests/Fixtures/Command/DaemonCommandConcreteThrowException.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DaemonCommandConcreteThrowException extends DaemonCommand
 {
-    public static $exceptionMessage = null;
+    public static ?string $exceptionMessage = null;
 
     protected function configure(): void
     {
@@ -20,9 +20,9 @@ class DaemonCommandConcreteThrowException extends DaemonCommand
     /**
      * @throws \Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        self::$exceptionMessage = (string) uniqid(mt_rand(), true);
+        self::$exceptionMessage = uniqid(mt_rand(), true);
 
         throw new \Exception(self::$exceptionMessage);
     }

--- a/tests/Fixtures/Command/DaemonCommandConcreteThrowStopException.php
+++ b/tests/Fixtures/Command/DaemonCommandConcreteThrowStopException.php
@@ -4,6 +4,7 @@ namespace M6Web\Bundle\DaemonBundle\Tests\Fixtures\Command;
 
 use M6Web\Bundle\DaemonBundle\Command\DaemonCommand;
 use M6Web\Bundle\DaemonBundle\Command\StopLoopException;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -16,7 +17,7 @@ class DaemonCommandConcreteThrowStopException extends DaemonCommand
     public const EXCEPTION_MESSAGE = 'Stop loop exception';
 
     /** @var int */
-    private $count = 0;
+    private int $count = 0;
 
     protected function configure(): void
     {
@@ -28,10 +29,11 @@ class DaemonCommandConcreteThrowStopException extends DaemonCommand
     /**
      * @throws StopLoopException
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (++$this->count >= static::MAX_ITERATION) {
             throw new StopLoopException(static::EXCEPTION_MESSAGE);
         }
+        return Command::FAILURE;
     }
 }

--- a/tests/Unit/Command/DaemonCommandTest.php
+++ b/tests/Unit/Command/DaemonCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace M6Web\Bundle\DaemonBundle\Tests\Units\Command;
+namespace M6Web\Bundle\DaemonBundle\Tests\Unit\Command;
 
 use Exception;
 use M6Web\Bundle\DaemonBundle\Command\DaemonCommand;
@@ -20,26 +20,23 @@ use M6Web\Bundle\DaemonBundle\Tests\Fixtures\Command\DaemonCommandConcreteThrowE
 use M6Web\Bundle\DaemonBundle\Tests\Fixtures\Command\DaemonCommandConcreteThrowStopException;
 use M6Web\Bundle\DaemonBundle\Tests\Fixtures\Event\EachFiveEvent;
 use M6Web\Bundle\DaemonBundle\Tests\Fixtures\Event\EachTenEvent;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class DaemonCommandTest extends TestCase
 {
-    /** @var MockObject|EventDispatcherInterface */
-    protected $eventDispatcher;
+    protected ?EventDispatcherInterface $eventDispatcher;
 
-    /** @var LoopInterface */
-    protected $loop;
+    protected ?LoopInterface $loop;
 
     public function setUp(): void
     {
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->loop = Factory::create();
+        $this->loop = Loop::get();
     }
 
     public function tearDown(): void
@@ -50,7 +47,7 @@ class DaemonCommandTest extends TestCase
 
     private function createDaemonCommand(
         string $class = DaemonCommandConcrete::class,
-        EventDispatcherInterface $eventDispatcher = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
         array $iterationEvents = []
     ): DaemonCommand {
         /** @var DaemonCommand $command */
@@ -97,14 +94,14 @@ class DaemonCommandTest extends TestCase
 
         // With
         $this->assertIsBool($command->isShutdownRequested());
-        $this->assertEquals(false, $command->isShutdownRequested());
+        $this->assertFalse($command->isShutdownRequested());
 
         // When
         $command->requestShutdown();
 
         // Then
         $this->assertIsBool($command->isShutdownRequested());
-        $this->assertEquals(true, $command->isShutdownRequested());
+        $this->assertTrue($command->isShutdownRequested());
     }
 
     /**
@@ -340,7 +337,7 @@ class DaemonCommandTest extends TestCase
         );
 
         // Then
-        $this->assertInstanceOf(\Exception::class, $exception = $command->getLastException());
+        $this->assertInstanceOf(\Exception::class, $command->getLastException());
         $this->assertStringContainsString(DaemonCommandConcreteThrowException::$exceptionMessage, $commandTester->getDisplay());
         $this->assertStringContainsString('Exception', $commandTester->getDisplay());
     }
@@ -374,7 +371,7 @@ class DaemonCommandTest extends TestCase
         );
 
         // Then
-        $this->assertInstanceOf(\Exception::class, $exception = $command->getLastException());
+        $this->assertInstanceOf(\Exception::class, $command->getLastException());
         $this->assertStringNotContainsString(DaemonCommandConcreteThrowException::$exceptionMessage, $commandTester->getDisplay());
         $this->assertStringNotContainsString('Exception', $commandTester->getDisplay());
 


### PR DESCRIPTION
Fixing deprecation to upgrade to symfony 7
Minor changes on php typing compatibilty (set minimal php version to 8.2)
Fixes #40